### PR TITLE
Fix for issue #6

### DIFF
--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -1461,13 +1461,15 @@ script ScriptEditorLogger
 			aColor <em>[RGB color]</em> The text color.
 	*)
 	on printColoredString(aString, aColor)
-		tell my textView
-			set selection to insertion point -1
-			set contents of selection to aString
-			if aColor is not missing value then Â
-				set color of contents of selection to aColor
-			set selection to insertion point -1
-		end tell
+		using terms from application id "com.apple.ScriptEditor2"
+			tell my textView
+				set selection to insertion point -1
+				set contents of selection to aString
+				if aColor is not missing value then Â
+					set color of contents of selection to aColor
+				set selection to insertion point -1
+			end tell
+		end using terms from
 	end printColoredString
 	
 	(*!


### PR DESCRIPTION
Because both Script Debugger.app and Script Editor.app have a "selection" property, if the ASUnit library was built with Script Debugger, the wrong raw chevron syntax for "selection" («property psel») is pulled from Script Debugger's dictionary rather than «property sele» from Script Editor's dictionary.

I reported this issue to the Script Debugger.app developer, and he explain that this isn't a bug, it's how OSA naturally resolves terminology based on the context, so it's necessary to explicitly target Script Editor's dictionary with `using terms from`