### PR TITLE
Respecify license and copyright

### DIFF
--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -2,7 +2,7 @@
 	@header ASUnit
 		An AppleScript testing framework.
 	@author Nir Soffer, Lifepillar
-	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer
 	@license GNU GPL-2.0, see COPYING for details.
 	@version 1.2.4
 	@charset utf-8

--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -1,9 +1,10 @@
 (*!
 	@header ASUnit
 		An AppleScript testing framework.
+	@abstract A free and open source unit testing tool for AppleScript.
 	@author Nir Soffer, Lifepillar
-	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer
-	@license GNU GPL-2.0, see COPYING for details.
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer. All rights reserved.
+	@license Licensed under GNU GPL-2.0 License, see COPYING for details.
 	@version 1.2.4
 	@charset utf-8
 *)

--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -1,9 +1,9 @@
 (*!
 	@header ASUnit
 		An AppleScript testing framework.
-	@abstract License: GNU GPL-2.0, see COPYING for details.
 	@author Nir Soffer, Lifepillar
 	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
+	@license GNU GPL-2.0, see COPYING for details.
 	@version 1.2.4
 	@charset utf-8
 *)

--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -1,7 +1,7 @@
 (*!
 	@header ASUnit
 		An AppleScript testing framework.
-	@abstract License: GNU GPL, see COPYING for details.
+	@abstract License: GNU GPL-2.0, see COPYING for details.
 	@author Nir Soffer, Lifepillar
 	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
 	@version 1.2.4
@@ -88,7 +88,7 @@ on makeTestResult(aName)
 				Makes the given object an observer of TestResult.
 			@discussion
 				Observers of TestResult are sent notifications whenever
-				certain events occur, like starting a test, completing a test, etcÉ
+				certain events occur, like starting a test, completing a test, etcÃ‰
 				An observer should be an object that inherits from @link Observer @/link,
 				or at least conforms to its interface.
 			@param
@@ -532,7 +532,7 @@ on makeAssertions(theParent)
 			else
 				set min to e2
 			end if
-			if n > min * eps then Â
+			if n > min * eps then Ã‚
 				fail("The relative error is " & asText(n / min) & " > " & asText(eps))
 			countAssertion()
 		end assertEqualRelError
@@ -585,7 +585,7 @@ on makeAssertions(theParent)
 				fail("Can't get class of" & space & pp(expr) & ".")
 			end try
 			if k is not klass then
-				fail("Expected class: " & pp(klass) & linefeed & Â
+				fail("Expected class: " & pp(klass) & linefeed & Ã‚
 					"  Actual class: " & pp(k))
 			end if
 			countAssertion()
@@ -609,7 +609,7 @@ on makeAssertions(theParent)
 				countAssertion()
 				return
 			end try
-			if k is klass then Â
+			if k is klass then Ã‚
 				fail("Expected class of " & pp(expr) & linefeed & "to be different from " & pp(klass) & ".")
 			countAssertion()
 		end refuteInstanceOf
@@ -662,7 +662,7 @@ on makeAssertions(theParent)
 					error "Unexpected error: " & errMsg number errNum
 				end try
 			end repeat
-			fail(pp(expr) & space & "is not a kind of" & space & pp(klass) & "." & linefeed & Â
+			fail(pp(expr) & space & "is not a kind of" & space & pp(klass) & "." & linefeed & Ã‚
 				formatInheritanceChain(inheritanceChain))
 		end assertKindOf
 		
@@ -706,7 +706,7 @@ on makeAssertions(theParent)
 					error "Unexpected error: " & errMsg number errNum
 				end try
 			end repeat
-			fail(pp(expr) & space & "is a kind of" & space & pp(klass) & "." & linefeed & Â
+			fail(pp(expr) & space & "is a kind of" & space & pp(klass) & "." & linefeed & Ã‚
 				formatInheritanceChain(inheritanceChain))
 		end refuteKindOf
 		
@@ -745,7 +745,7 @@ on makeAssertions(theParent)
 					error "Unexpected error: " & errMsg number errNum
 				end try
 			end repeat
-			fail(pp(descendant) & space & "does not inherit from" & space & pp(ancestor) & "." & linefeed & Â
+			fail(pp(descendant) & space & "does not inherit from" & space & pp(ancestor) & "." & linefeed & Ã‚
 				formatInheritanceChain(inheritanceChain))
 		end assertInheritsFrom
 		
@@ -784,7 +784,7 @@ on makeAssertions(theParent)
 					error "Unexpected error: " & errMsg number errNum
 				end try
 			end repeat
-			fail(pp(anotherObj) & space & "inherits from" & space & pp(obj) & "." & linefeed & Â
+			fail(pp(anotherObj) & space & "inherits from" & space & pp(obj) & "." & linefeed & Ã‚
 				formatInheritanceChain(inheritanceChain))
 		end refuteInheritsFrom
 		
@@ -963,7 +963,7 @@ on makeAssertions(theParent)
 				try
 					set referencedObject to contents of anObject
 				on error
-					return "Çundefined referenceÈ"
+					return "Ã‡undefined referenceÃˆ"
 				end try
 				
 				if anObject is not equal to referencedObject then
@@ -971,7 +971,7 @@ on makeAssertions(theParent)
 				end if
 				
 				-- Is it an Objective-C reference?
-				if isCocoaRef(anObject) then return "Çclass ocidÈ"
+				if isCocoaRef(anObject) then return "Ã‡class ocidÃˆ"
 				
 				-- Is it a file reference?
 				try
@@ -980,7 +980,7 @@ on makeAssertions(theParent)
 					end if
 				end try
 				try
-					anObject as Çclass furlÈ
+					anObject as Ã‡class furlÃˆ
 					return "file" & space & asText(anObject)
 				end try
 				
@@ -1009,18 +1009,18 @@ on makeAssertions(theParent)
 				set klass to class of anObject
 			on error
 				try
-					return "Ç" & asText(anObject's name) & "È"
+					return "Ã‡" & asText(anObject's name) & "Ãˆ"
 				end try
 				try
-					return "Ç" & asText(anObject's id) & "'È"
+					return "Ã‡" & asText(anObject's id) & "'Ãˆ"
 				end try
 				try
-					return "Ç" & asText(anObject's description) & "È"
+					return "Ã‡" & asText(anObject's description) & "Ãˆ"
 				end try
 				try
 					return asText(anObject)
 				on error -- Give up
-					return "ÇobjectÈ"
+					return "Ã‡objectÃˆ"
 				end try
 			end try
 			
@@ -1037,7 +1037,7 @@ on makeAssertions(theParent)
 			end if
 			
 			if klass is record then
-				return "Çrecord " & _pp(anObject as list, depth + 1) & "È"
+				return "Ã‡record " & _pp(anObject as list, depth + 1) & "Ãˆ"
 			end if -- list, RGB color
 			
 			if klass is script or klass is application or klass is null then
@@ -1057,20 +1057,20 @@ on makeAssertions(theParent)
 				end try
 				
 				if klass is script then
-					return "Çscript" & space & res & "È"
+					return "Ã‡script" & space & res & "Ãˆ"
 				else
-					return "Çapplication" & space & res & "È"
+					return "Ã‡application" & space & res & "Ãˆ"
 				end if
 			end if -- script, application, null
 			
-			if klass is handler then return "ÇhandlerÈ"
+			if klass is handler then return "Ã‡handlerÃˆ"
 			
 			try
 				set res to asText(anObject)
 			on error
-				if klass is anObject then return "Çobject of class selfÈ"
+				if klass is anObject then return "Ã‡object of class selfÃˆ"
 				try
-					return "Çobject of class" & space & _pp(klass, depth + 1) & "È"
+					return "Ã‡object of class" & space & _pp(klass, depth + 1) & "Ãˆ"
 				on error errMsg
 					return "ERROR:" & errMsg -- We should never get here
 				end try
@@ -1082,19 +1082,19 @@ on makeAssertions(theParent)
 					set tid to AppleScript's text item delimiters
 					set AppleScript's text item delimiters to space
 					set x to text items of res
-					set AppleScript's text item delimiters to Çdata utxtFF65È as Unicode text -- small bullet
+					set AppleScript's text item delimiters to Ã‡data utxtFF65Ãˆ as Unicode text -- small bullet
 					set res to x as text
 					set AppleScript's text item delimiters to tab
 					set x to text items of res
-					set AppleScript's text item delimiters to Çdata utxt21A6È as Unicode text -- rightwards arrow from bar
+					set AppleScript's text item delimiters to Ã‡data utxt21A6Ãˆ as Unicode text -- rightwards arrow from bar
 					set res to x as text
 					set AppleScript's text item delimiters to linefeed
 					set x to text items of res
-					set AppleScript's text item delimiters to Çdata utxt00ACÈ as Unicode text -- not sign
+					set AppleScript's text item delimiters to Ã‡data utxt00ACÃˆ as Unicode text -- not sign
 					set res to x as text
 					set AppleScript's text item delimiters to return
 					set x to text items of res
-					set AppleScript's text item delimiters to Çdata utxt21A9È as Unicode text -- hook arrow
+					set AppleScript's text item delimiters to Ã‡data utxt21A9Ãˆ as Unicode text -- hook arrow
 					set res to x as text
 					set AppleScript's text item delimiters to tid
 				end if
@@ -1338,11 +1338,11 @@ script TestLogger
 			set elapsed to runSeconds()
 			set timeMsg to (elapsed as text) & " second"
 			if elapsed is not 1 then set timeMsg to timeMsg & "s"
-			set counts to {runCount() & " tests, ", Â
-				passCount() & " passed (", Â
-				assertionCount() & " assertions), ", Â
-				failureCount() & " failures, ", Â
-				errorCount() & " errors, ", Â
+			set counts to {runCount() & " tests, ", Ã‚
+				passCount() & " passed (", Ã‚
+				assertionCount() & " assertions), ", Ã‚
+				failureCount() & " failures, ", Ã‚
+				errorCount() & " errors, ", Ã‚
 				skipCount() & " skips."}
 		end tell
 		printLine("Finished in " & timeMsg & ".")
@@ -1464,7 +1464,7 @@ script ScriptEditorLogger
 			tell my textView
 				set selection to insertion point -1
 				set contents of selection to aString
-				if aColor is not missing value then Â
+				if aColor is not missing value then Ã‚
 					set color of contents of selection to aColor
 				set selection to insertion point -1
 			end tell
@@ -1528,7 +1528,7 @@ end script -- ConsoleLogger
 (*! @abstract Prints colorful test results to the standard output. *)
 script StdoutLogger
 	property parent : TestLogger
-	property esc : Çdata utxt001BÈ as Unicode text
+	property esc : Ã‡data utxt001BÃˆ as Unicode text
 	property black : esc & "[0;30m"
 	property blue : esc & "[0;34m"
 	property cyan : esc & "[0;36m"
@@ -1881,9 +1881,9 @@ on makeTestLoader()
 			compileSourceFiles(aFolder)
 			
 			tell application "Finder"
-				set testFiles to files of aFolder Â
-					where name starts with my prefix and name ends with Â
-					".scpt" and name does not start with Â
+				set testFiles to files of aFolder Ã‚
+					where name starts with my prefix and name ends with Ã‚
+					".scpt" and name does not start with Ã‚
 					"Test Load" and name does not start with "TestLoad"
 			end tell
 			repeat with aFile in testFiles
@@ -1896,16 +1896,16 @@ on makeTestLoader()
 		(*! @abstract Compiles all the test scripts in the specified folder. *)
 		on compileSourceFiles(aFolder)
 			tell application "Finder"
-				set testFiles to files of aFolder Â
-					where name starts with my prefix and name ends with Â
-					".applescript" and name does not start with Â
+				set testFiles to files of aFolder Ã‚
+					where name starts with my prefix and name ends with Ã‚
+					".applescript" and name does not start with Ã‚
 					"Test Load" and name does not start with "TestLoad"
 			end tell
 			repeat with aFile in testFiles
-				set outfile to (text 1 thru -(2 + (length of (aFile's name extension as text))) Â
+				set outfile to (text 1 thru -(2 + (length of (aFile's name extension as text))) Ã‚
 					of (aFile's name as text)) & ".scpt"
-				set cmd to "osacompile -d -o " & space & Â
-					quoted form of (POSIX path of (aFolder as alias) & outfile) & space & Â
+				set cmd to "osacompile -d -o " & space & Ã‚
+					quoted form of (POSIX path of (aFolder as alias) & outfile) & space & Ã‚
 					quoted form of POSIX path of (aFile as alias)
 				try
 					do shell script cmd

--- a/OldManual.md
+++ b/OldManual.md
@@ -364,11 +364,11 @@ See the source of `TextTestRunner` for example.
 
 ## Copyright
 
-Copyright © 2006 Nir Soffer
+Copyright © 2006 Nir Soffer. All rights reserved.
 
 ## License
 
-[GNU GPL-2.0][GNU-GPLv2], see COPYING for details
+This software is licensed under the [GNU GPL-2.0][GNU-GPLv2] License, see COPYING for details.
 
 [//]: # (Cross reference section)
 

--- a/OldManual.md
+++ b/OldManual.md
@@ -362,12 +362,13 @@ single test cases results, you should set your runner as observer of the `TestRe
 See the source of `TextTestRunner` for example. 
 
 
+## Copyright
+
+Copyright © 2006 Nir Soffer
+
 ## License
 
-**copyright:** © 2006 Nir Soffer
-
-**license:** [GNU GPL-2.0][GNU-GPLv2], see COPYING for details
-
+[GNU GPL-2.0][GNU-GPLv2], see COPYING for details
 
 [//]: # (Cross reference section)
 

--- a/OldManual.md
+++ b/OldManual.md
@@ -366,4 +366,9 @@ See the source of `TextTestRunner` for example.
 
 **copyright:** © 2006 Nir Soffer
 
-**license:** GNU GPL, see COPYING for details
+**license:** [GNU GPL-2.0][GNU-GPLv2], see COPYING for details
+
+
+[//]: # (Cross reference section)
+
+[GNU-GPLv2]: https://opensource.org/license/gpl-2-0

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ property of the script explicitly.
 
 ## Copyright
 
-Copyright © 2013–2023 Lifepillar, 2006 Nir Soffer
+Copyright © 2013–2025 Lifepillar, 2006 Nir Soffer
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,14 @@ as it was done in the example above. Alternatively, you may define the `name`
 property of the script explicitly.
 
 
-### License
-
-GNU GPL, see COPYING for details.
+## Copyright
 
 Copyright © 2013–2023 Lifepillar, 2006 Nir Soffer
+
+## License
+
+[GNU GPL-2.0][GNU-GPLv2], see COPYING for details.
+
+[//]: # (Cross reference section)
+
+[GNU-GPLv2]: https://opensource.org/license/gpl-2-0

--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ property of the script explicitly.
 
 ## Copyright
 
-Copyright © 2013–2025 Lifepillar, 2006 Nir Soffer
+Copyright © 2013–2025 Lifepillar, 2006 Nir Soffer. All rights reserved.
 
 ## License
 
-[GNU GPL-2.0][GNU-GPLv2], see COPYING for details.
+This software is licensed under the [GNU GPL-2.0][GNU-GPLv2] License, see COPYING for details.
 
 [//]: # (Cross reference section)
 

--- a/test/Test ASUnit.applescript
+++ b/test/Test ASUnit.applescript
@@ -1,7 +1,7 @@
 (*!
 	@header ASUnit
 		ASUnit self tests.
-	@abstract License: GNU GPL, see COPYING for details.
+	@abstract License: GNU GPL-2.0, see COPYING for details.
 	@author NirSoffer, Lifepillar
 	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
 *)
@@ -88,7 +88,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's Observer's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"Observer should not define TEST_FAILED.")
 		assertEqual(AppleScript, ASUnit's Observer's parent)
 		assertEqual("Observer", ASUnit's Observer's name)
@@ -100,7 +100,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's Visitor's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"Visitor should not define TEST_FAILED.")
 		assertEqual(AppleScript, ASUnit's Visitor's parent)
 		assertEqual("Visitor", ASUnit's Visitor's name)
@@ -114,7 +114,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			TestResult's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestResult should not define TEST_FAILED.")
 		assertEqual(ASUnit's Visitor, TestResult's parent)
 		assertEqual("Name of test result", TestResult's name)
@@ -128,7 +128,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			TestAssertions's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestAssertions should not define TEST_FAILED.")
 		assertEqual(ASUnit's TestCase, TestAssertions's parent)
 		assertEqual("TestAssertions", TestAssertions's name)
@@ -140,7 +140,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's TestLogger's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestLogger should not define TEST_FAILED.")
 		assertEqual(ASUnit's Observer, ASUnit's TestLogger's parent)
 		assertEqual("TestLogger", ASUnit's TestLogger's name)
@@ -152,7 +152,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's ScriptEditorLogger's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"ScriptEditorLogger should not define TEST_FAILED.")
 		assertEqual(ASUnit's TestLogger, ASUnit's ScriptEditorLogger's parent)
 		assertEqual("ScriptEditorLogger", ASUnit's ScriptEditorLogger's name)
@@ -164,7 +164,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's ConsoleLogger's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"ConsoleLogger should not define TEST_FAILED.")
 		assertEqual(ASUnit's TestLogger, ASUnit's ConsoleLogger's parent)
 		assertEqual("ConsoleLogger", ASUnit's ConsoleLogger's name)
@@ -176,7 +176,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's ASUnitSentinel's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"ASUnitSentinel should not define TEST_FAILED.")
 		assertEqual(AppleScript, ASUnit's ASUnitSentinel's parent)
 		refuteInheritsFrom(ASUnit, ASUnit's ASUnitSentinel)
@@ -187,7 +187,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's TestComponent's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestComponent should not define TEST_FAILED.")
 		assertEqual(AppleScript, ASUnit's TestComponent's parent)
 		assertEqual("TestComponent", ASUnit's TestComponent's name)
@@ -199,7 +199,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			ASUnit's TestCase's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestCase should not define TEST_FAILED.")
 		assertEqual(ASUnit's TestComponent, ASUnit's TestCase's parent)
 		assertEqual("TestCase", ASUnit's TestCase's name)
@@ -213,7 +213,7 @@ script |ASUnit architecture|
 		script DoesNotInheritFromTopLevel
 			TestSuite's TEST_FAILED
 		end script
-		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, ¬
+		shouldRaise(cantGetVar, DoesNotInheritFromTopLevel, √Ç
 			"TestSuite should not define TEST_FAILED.")
 		assertEqual(ASUnit's TestComponent, TestSuite's parent)
 		assertEqual("Name of test suite", TestSuite's name)
@@ -380,7 +380,7 @@ script |assert instance of|
 		-- should be 'application' according to The AppleScript Language Guide
 		assertInstanceOf(null, application "Finder") -- AS bug?
 		set f to POSIX file "/Users/myUser/Feb_Meeting_Notes.rtf"
-		assertInstanceOf(«class furl», f) -- shouldn't be 'file'?
+		assertInstanceOf(√áclass furl√à, f) -- shouldn't be 'file'?
 		assertInstanceOf(grams, 1 as grams)
 		refuteInstanceOf(number, 1)
 		refuteInstanceOf(real, 1)
@@ -611,14 +611,14 @@ script skipping
 		property parent : UnitTest(me)
 		set aResult to |skipping test helper|'s test's test()
 		should(aResult's hasPassed(), "test failed")
-		should(aResult's skipCount() = 1, "skipCount ≠ 1")
+		should(aResult's skipCount() = 1, "skipCount ¬≠ 1")
 	end script
 	
 	script |skipping setup|
 		property parent : UnitTest(me)
 		set aResult to |skipping setup helper|'s test's test()
 		should(aResult's hasPassed(), "test failed")
-		should(aResult's skipCount() = 1, "skipCount ≠ 1")
+		should(aResult's skipCount() = 1, "skipCount ¬≠ 1")
 	end script
 	
 end script
@@ -675,21 +675,21 @@ script errors
 		property parent : UnitTest(me)
 		set aResult to |errors setUp helper|'s test's test()
 		shouldnt(aResult's hasPassed(), "error in setup ignored")
-		should(aResult's errorCount() = 1, "errorCount ≠ 1")
+		should(aResult's errorCount() = 1, "errorCount ¬≠ 1")
 	end script
 	
 	script |error in test case|
 		property parent : UnitTest(me)
 		set aResult to |errors test case helper|'s test's test()
 		shouldnt(aResult's hasPassed(), "error in test case ignored")
-		should(aResult's errorCount() = 1, "errorCount ≠ 1")
+		should(aResult's errorCount() = 1, "errorCount ¬≠ 1")
 	end script
 	
 	script |error in tearDown|
 		property parent : UnitTest(me)
 		set aResult to |errors tearDown helper|'s test's test()
 		shouldnt(aResult's hasPassed(), "error in tearDown ignored")
-		should(aResult's errorCount() = 1, "errorCount ≠ 1")
+		should(aResult's errorCount() = 1, "errorCount ¬≠ 1")
 	end script
 	
 end script
@@ -808,14 +808,14 @@ script |tearDown|
 	script |run after skipping test|
 		property parent : UnitTest(me)
 		set aResult to (|tearDown helper|'s |skipping test|'s test())
-		if aResult's skipCount() ≠ 1 then error "skipping test did not skip, can't test tearDown"
+		if aResult's skipCount() ¬≠ 1 then error "skipping test did not skip, can't test tearDown"
 		should(|tearDown helper|'s tearDownDidRun, name)
 	end script
 	
 	script |run after skip in setup|
 		property parent : UnitTest(me)
 		set aResult to (|skip in setUp helper|'s test's test())
-		if aResult's skipCount() ≠ 1 then error "there was no skip, can't test tearDown"
+		if aResult's skipCount() ¬≠ 1 then error "there was no skip, can't test tearDown"
 		should(|skip in setUp helper|'s tearDownDidRun, name)
 	end script
 	
@@ -885,11 +885,11 @@ script |analyze results|
 		aSuite's add(|analyze helper|'s |error|)
 		aSuite's add(|analyze helper|'s failure)
 		set aResult to aSuite's test()
-		should(aResult's runCount() = 5, "runCount ≠ 5")
-		should(aResult's passCount() = 2, "passCount ≠ 2")
-		should(aResult's skipCount() = 1, "skipCount ≠ 1")
-		should(aResult's failureCount() = 1, "failureCount ≠ 1")
-		should(aResult's errorCount() = 1, "errorCount ≠ 1")
+		should(aResult's runCount() = 5, "runCount ¬≠ 5")
+		should(aResult's passCount() = 2, "passCount ¬≠ 2")
+		should(aResult's skipCount() = 1, "skipCount ¬≠ 1")
+		should(aResult's failureCount() = 1, "failureCount ¬≠ 1")
+		should(aResult's errorCount() = 1, "errorCount ¬≠ 1")
 	end script
 	
 	script |suite with success should pass|
@@ -1043,11 +1043,11 @@ script |shouldRaise|
 			error number 9876
 		end script
 		
-		shouldRaise({1, 2, 3, 1000, 9876, 10000}, Raiser, ¬
+		shouldRaise({1, 2, 3, 1000, 9876, 10000}, Raiser, √Ç
 			"The script should have raised exception 9876.")
-		shouldRaise({}, Raiser, ¬
+		shouldRaise({}, Raiser, √Ç
 			"The script should have raised exception 9876")
-		shouldNotRaise({1, 2, 3, 1000, 10000}, Raiser, ¬
+		shouldNotRaise({1, 2, 3, 1000, 10000}, Raiser, √Ç
 			"The script has raised a forbidden exception.")
 	end script
 	
@@ -1142,18 +1142,18 @@ script |pretty print|
 	script |pp alias|
 		property parent : UnitTest(me)
 		assertEqual("alias" & space & ((path to me) as text), pp(path to me))
-		assertEqual("alias" & space & ((path to me) as text), ¬
+		assertEqual("alias" & space & ((path to me) as text), √Ç
 			pp(a reference to (path to me)))
-		assertEqual("alias" & space & ((path to me) as text), ¬
+		assertEqual("alias" & space & ((path to me) as text), √Ç
 			pp(a reference to (a reference to (path to me))))
 	end script
 	
 	script |pp application|
 		property parent : UnitTest(me)
-		assertEqual("«application com.apple.finder»", pp(application "Finder"))
-		assertEqual("«application com.apple.finder»", ¬
+		assertEqual("√áapplication com.apple.finder√à", pp(application "Finder"))
+		assertEqual("√áapplication com.apple.finder√à", √Ç
 			pp(a reference to (application "Finder")))
-		assertEqual("«application com.apple.finder»", ¬
+		assertEqual("√áapplication com.apple.finder√à", √Ç
 			pp(a reference to (a reference to (application "Finder"))))
 	end script
 	
@@ -1184,7 +1184,7 @@ script |pretty print|
 	script |pp constant|
 		property parent : UnitTest(me)
 		set x to missing value
-		assertEqual("«" & current application's name & "»", pp(current application))
+		assertEqual("√á" & current application's name & "√à", pp(current application))
 		assertEqual("missing value", pp(missing value))
 		assertEqual("missing value", pp(x))
 		assertEqual("null", pp(null))
@@ -1192,10 +1192,10 @@ script |pretty print|
 		assertEqual(pi as text, pp(pi))
 		assertEqual(quote, pp(quote))
 		assert(my showInvisibles, "Show invisibles should be turned on by default")
-		assertEqual(«data utxt00AC» as Unicode text, pp(linefeed)) -- not sign
-		assertEqual(«data utxt21A9» as Unicode text, pp(return)) -- hook arrow
-		assertEqual(«data utxtFF65» as Unicode text, pp(space)) -- small bullet
-		assertEqual(«data utxt21A6» as Unicode text, pp(tab)) -- rightwards arrow from bar
+		assertEqual(√ádata utxt00AC√à as Unicode text, pp(linefeed)) -- not sign
+		assertEqual(√ádata utxt21A9√à as Unicode text, pp(return)) -- hook arrow
+		assertEqual(√ádata utxtFF65√à as Unicode text, pp(space)) -- small bullet
+		assertEqual(√ádata utxt21A6√à as Unicode text, pp(tab)) -- rightwards arrow from bar
 		set my showInvisibles to false
 		assertEqual(linefeed, pp(linefeed))
 		assertEqual(return, pp(return))
@@ -1226,8 +1226,8 @@ script |pretty print|
 		on f(x, y)
 		end f
 		
-		assertEqual("«handler»", pp(f))
-		assertEqual("a reference to «handler»", pp(a reference to f))
+		assertEqual("√áhandler√à", pp(f))
+		assertEqual("a reference to √áhandler√à", pp(a reference to f))
 	end script
 	
 	script |pp list|
@@ -1235,7 +1235,7 @@ script |pretty print|
 		assertEqual("{}", pp({}))
 		assertEqual("{1, " & (3.4 as text) & ", abc}", pp({1, 3.4, "abc"}))
 		assertEqual("{1, {2, {3, 4}}, 5}", pp({1, {2, {3, 4}}, 5}))
-		assertEqual("{«script pp list», «record {1, {«application com.apple.finder», {1, 2}}, x}», true}", ¬
+		assertEqual("{√áscript pp list√à, √árecord {1, {√áapplication com.apple.finder√à, {1, 2}}, x}√à, true}", √Ç
 			pp({me, {a:1, b:{application "Finder", {1, 2}}, c:"x"}, true}))
 	end script
 	
@@ -1256,13 +1256,13 @@ script |pretty print|
 		assertEqual("file" & space & (f as text), pp(f))
 		assertEqual("a reference to file" & space & (f as text), pp(f1))
 		assertEqual("a reference to file" & space & (f as text), pp(a reference to f))
-		assertEqual("a reference to a reference to file" & space & (f as text), ¬
+		assertEqual("a reference to a reference to file" & space & (f as text), √Ç
 			pp(f2))
 	end script
 	
 	script |pp record|
 		property parent : UnitTest(me)
-		assertEqual("«record {1, 2, 3}»", pp({a:1, b:2, c:3}))
+		assertEqual("√árecord {1, 2, 3}√à", pp({a:1, b:2, c:3}))
 	end script
 	
 	script |pp script|
@@ -1273,11 +1273,11 @@ script |pretty print|
 			property id : "com.lifepillar.ppscript"
 		end script
 		
-		assertEqual("«script pp script»", pp(me))
-		assertEqual("«script pp script»", pp(a reference to me))
-		assertEqual("«script pp script»", pp(a reference to (a reference to me)))
-		assertEqual("«script com.lifepillar.ppscript»", pp(ppScript))
-		assertEqual("a reference to «script com.lifepillar.ppscript»", pp(ppScriptRef))
+		assertEqual("√áscript pp script√à", pp(me))
+		assertEqual("√áscript pp script√à", pp(a reference to me))
+		assertEqual("√áscript pp script√à", pp(a reference to (a reference to me)))
+		assertEqual("√áscript com.lifepillar.ppscript√à", pp(ppScript))
+		assertEqual("a reference to √áscript com.lifepillar.ppscript√à", pp(ppScriptRef))
 	end script
 	
 	script |pp script called 'missing value'|
@@ -1289,21 +1289,21 @@ script |pretty print|
 			property name : "missing value"
 		end script
 		
-		assertEqual("«script missing value»", pp(ppScript))
-		assertEqual("a reference to «script missing value»", pp(ppScriptRef))
+		assertEqual("√áscript missing value√à", pp(ppScript))
+		assertEqual("a reference to √áscript missing value√à", pp(ppScriptRef))
 	end script
 	
 	script |pp ASUnit|
 		property parent : UnitTest(me)
 		property scriptRef : a reference to TestASUnit's ASUnit
 		
-		assertEqual("a reference to «script" & space & ASUnit's id & "»", pp(TestASUnit's ASUnit))
-		assertEqual("a reference to a reference to «script" & space & ASUnit's id & "»", pp(scriptRef))
+		assertEqual("a reference to √áscript" & space & ASUnit's id & "√à", pp(TestASUnit's ASUnit))
+		assertEqual("a reference to a reference to √áscript" & space & ASUnit's id & "√à", pp(scriptRef))
 	end script
 	
 	script |pp text|
 		property parent : UnitTest(me)
-		assertEqual("àèìòùñ©", pp("àèìòùñ©"))
+		assertEqual("¬à¬è¬ì¬ò¬ù¬ñ¬©", pp("¬à¬è¬ì¬ò¬ù¬ñ¬©"))
 	end script
 	
 	script |pp unit types|
@@ -1357,7 +1357,7 @@ script |pretty print|
 			property class : me -- Weird, but legal
 		end script
 		
-		assertEqual("«object of class self»", pp(Self))
+		assertEqual("√áobject of class self√à", pp(Self))
 	end script
 	
 	script |pp recursive undefined|
@@ -1371,8 +1371,8 @@ script |pretty print|
 			property class : SX
 		end script
 		
-		assertEqual("«object of class «undefined reference»»", pp(SX))
-		assertEqual("«object of class «object of class «undefined reference»»»", pp(SY))
+		assertEqual("√áobject of class √áundefined reference√à√à", pp(SX))
+		assertEqual("√áobject of class √áobject of class √áundefined reference√à√à√à", pp(SY))
 	end script
 	
 	property PPRL : a reference to |pp recursive loop|
@@ -1389,8 +1389,8 @@ script |pretty print|
 		end script
 		
 		set my maxRecursionDepth to 4
-		assertEqual("«object of class a reference to «object of class «object of class a reference to ...»»»", pp(SX))
-		assertEqual("«object of class «object of class a reference to «object of class «object of class ...»»»»", pp(SY))
+		assertEqual("√áobject of class a reference to √áobject of class √áobject of class a reference to ...√à√à√à", pp(SX))
+		assertEqual("√áobject of class √áobject of class a reference to √áobject of class √áobject of class ...√à√à√à√à", pp(SY))
 	end script
 	
 	script |Pretty print document|

--- a/test/Test ASUnit.applescript
+++ b/test/Test ASUnit.applescript
@@ -2,7 +2,7 @@
 	@header ASUnit
 		ASUnit self tests.
 	@author NirSoffer, Lifepillar
-	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer
 	@license GNU GPL-2.0, see COPYING for details.
 *)
 use scripting additions

--- a/test/Test ASUnit.applescript
+++ b/test/Test ASUnit.applescript
@@ -1,9 +1,9 @@
 (*!
 	@header ASUnit
 		ASUnit self tests.
-	@abstract License: GNU GPL-2.0, see COPYING for details.
 	@author NirSoffer, Lifepillar
 	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
+	@license GNU GPL-2.0, see COPYING for details.
 *)
 use scripting additions
 use ASUnit : script "com.lifepillar/ASUnit"

--- a/test/Test ASUnit.applescript
+++ b/test/Test ASUnit.applescript
@@ -1,9 +1,10 @@
 (*!
 	@header ASUnit
 		ASUnit self tests.
+	@abstract Unit tests for this AppleScript source unit testing tool.
 	@author NirSoffer, Lifepillar
-	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer
-	@license GNU GPL-2.0, see COPYING for details.
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer. All rights reserved.
+	@license Licensed under GNU GPL-2.0 License, see COPYING for details.
 *)
 use scripting additions
 use ASUnit : script "com.lifepillar/ASUnit"


### PR DESCRIPTION
Various updates that use current year for `@copyright`, fleshed out both `@copyright` and `@license`, added license links as well. `@abstract` was made to show the file's raison d`être.

As documentation appears to be  generated, it was not included and requires update to match.