### PR TITLE
AppleScript comment headers updated

### DIFF
--- a/ASUnit.applescript
+++ b/ASUnit.applescript
@@ -1,17 +1,18 @@
 (*!
 	@header ASUnit
 		An AppleScript testing framework.
-	@abstract License: GNU GPL, see COPYING for details.
+	@abstract A free and open source unit testing tool for AppleScript.
 	@author Nir Soffer, Lifepillar
-	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
-	@version 1.2.4
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer. All rights reserved.
+	@license Licensed under GNU GPL-2.0 License, see COPYING for details.
+	@version 1.2.5
 	@charset utf-8
 *)
 
 (*! @abstract <em>[text]</em> ASUnit's name. *)
 property name : "ASUnit"
 (*! @abstract <em>[text]</em> ASUnit's version. *)
-property version : "1.2.4"
+property version : "1.2.5"
 (*! @abstract <em>[text]</em> ASUnit's id. *)
 property id : "com.lifepillar.ASUnit"
 (*! @abstract Error number signalling a failed test. *)

--- a/test/Test ASUnit.applescript
+++ b/test/Test ASUnit.applescript
@@ -1,9 +1,10 @@
 (*!
 	@header ASUnit
 		ASUnit self tests.
-	@abstract License: GNU GPL, see COPYING for details.
+	@abstract Unit tests for this AppleScript source unit testing tool.
 	@author NirSoffer, Lifepillar
-	@copyright 2013-2023 Lifepillar, 2006 Nir Soffer
+	@copyright 2013-2025 Lifepillar, 2006 Nir Soffer. All rights reserved.
+	@license Licensed under GNU GPL-2.0 License, see COPYING for details.
 *)
 use scripting additions
 use ASUnit : script "com.lifepillar/ASUnit"


### PR DESCRIPTION
Modified/created aspects of `@abstract`, `@copyright`, `@license`, `@date`, & `@version`. Hoping the text encoding doesn't get stripped. Resubmitted as first didn't put the test file in a directory.